### PR TITLE
I add Werkzeug to requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ opencc-python-reimplemented==0.1.4
 beautifulsoup4==4.11.2
 youtube-transcript-api==0.5.0
 pymongo==4.3.3
+Werkzeug==2.2.2


### PR DESCRIPTION
I add Werkzeug to requirement.txt, or the main.py can't run because it would return the words below.


------------------------------------------------------------------------------------------------
console(wrong)
------------------------------------------------------------------------------------------------
Traceback (most recent call last):
File "/home/runner/ChatGPT-Line-Bot/main.py", line 2, in
from flask import Flask, request, abort
File "/home/runner/ChatGPT-Line-Bot/.pythonlibs/lib/python3.10/site-packages/flask/init.py", line 5, in
from .app import Flask as Flask
File "/home/runner/ChatGPT-Line-Bot/.pythonlibs/lib/python3.10/site-packages/flask/app.py", line 30, in
from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/home/runner/ChatGPT-Line-Bot/.pythonlibs/lib/python3.10/site-packages/werkzeug/urls.py)
------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------